### PR TITLE
Receive full 64-bit NTP timestamp

### DIFF
--- a/examples/get_raw_timestamp.rs
+++ b/examples/get_raw_timestamp.rs
@@ -1,0 +1,13 @@
+//! Basic example for how to obtain a raw NTP timestamp from main NTP server.
+
+extern crate sntp_request;
+
+use sntp_request::SntpRequest;
+
+fn main() {
+    let sntp = SntpRequest::new();
+    let timestamp = sntp.get_raw_time().unwrap();
+    let nsec = (timestamp.frac as f64 / u32::max_value() as f64) * 1000.0;
+    println!("seconds: {} frac: {}", timestamp.secs, timestamp.frac);
+    println!("milliseconds: {}", nsec);
+}


### PR DESCRIPTION
Add the facility to extract the fractional part of the NTP response, allowing the recieved time to be exposed as a canonical NTP timestamp, comprising a 32-bit seconds field and a 32-bit fractional field. This allows the returned time value of a higher precision than was previously available.

Convert the functions returning raw timestamps to instead return a struct encapsulating an NTP timestamp.

Also add an example for raw timestamp reception.