### PR TITLE
Fix missing format!() in SNTP version error message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ impl SntpRequest {
                 if vn != 4 {
                     return Err(Error::new(
                         ErrorKind::Other,
-                        "Server returned wrong SNTP version {vn}, expected 4.",
+                        format!("Server returned wrong SNTP version {vn}, expected 4."),
                     ));
                 }
                 let mode = hdr & 0x7;


### PR DESCRIPTION
## Summary

The error message in `recv_packet()` used `"Server returned wrong SNTP version {vn}, expected 4."` as a plain string literal instead of wrapping it in `format!()`. This caused the error to display the literal text `{vn}` instead of the actual version number.

Closes #9

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — all tests pass