### PR TITLE
Fix u32 underflow in Unix timestamp calculation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ impl SntpRequest {
     pub fn get_unix_time_by_addr<A: ToSocketAddrs>(&self, addr: A) -> SntpUnixTimeResult {
         let raw_time = self.get_raw_time_by_addr(addr)?;
         let raw_secs = raw_time.secs;
-        Ok((raw_secs - SNTP_TIME_OFFSET) as i64)
+        Ok((raw_secs as i64) - (SNTP_TIME_OFFSET as i64))
     }
 
     /// Obtains the raw time from default NTP server address [`POOL_NTP_ADDR`](constant.POOL_NTP_ADDR.html).


### PR DESCRIPTION
## Summary

`get_unix_time_by_addr()` performed `(raw_secs - SNTP_TIME_OFFSET) as i64` where both operands are `u32`. If `raw_secs < SNTP_TIME_OFFSET` (e.g. dates before 1970 in NTP epoch), this causes a u32 underflow panic in debug mode or wraps silently in release mode. Fixed by casting both operands to `i64` before subtraction.

Closes #10

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — all tests pass