### PR TITLE
Add try_new() non-panicking constructor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,13 +61,24 @@ impl Default for SntpRequest {
 
 impl SntpRequest {
     /// Creates a new SNTP request object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the UDP socket cannot be bound or the timeout cannot be set.
+    /// Use [`try_new`](Self::try_new) for a non-panicking alternative.
     pub fn new() -> SntpRequest {
+        Self::try_new().expect("failed to create SNTP request")
+    }
+
+    /// Creates a new SNTP request object, returning an error instead of
+    /// panicking if the UDP socket cannot be bound or the timeout cannot be set.
+    pub fn try_new() -> io::Result<SntpRequest> {
         let sntp = SntpRequest {
-            socket: UdpSocket::bind("0.0.0.0:0").unwrap(),
+            socket: UdpSocket::bind("0.0.0.0:0")?,
             kiss_of_death: Cell::new(false),
         };
-        sntp.set_timeout(Duration::from_secs(5)).unwrap();
-        sntp
+        sntp.set_timeout(Duration::from_secs(5))?;
+        Ok(sntp)
     }
 
     #[inline]


### PR DESCRIPTION
## Summary

`SntpRequest::new()` uses `.unwrap()` on `UdpSocket::bind()` and `set_timeout()`, which panics if the socket cannot be created. Added `try_new()` that returns `io::Result<SntpRequest>` and documented the panic condition on `new()`.

Closes #11

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — all tests pass